### PR TITLE
Improve SEO meta and robots file

### DIFF
--- a/rusard_site/rusard_site/urls.py
+++ b/rusard_site/rusard_site/urls.py
@@ -21,6 +21,7 @@ import rusardhome.views as views
 import ts.views as ts_views
 from django.contrib.sitemaps.views import sitemap
 from rusardhome.sitemaps import StaticViewSitemap, ArticleSitemap
+from django.views.generic import TemplateView
 
 
 sitemaps = {
@@ -39,6 +40,7 @@ urlpatterns = [
     path('ts-tpf/', ts_views.tours_services, name='ts'),
     path('Contact/Confirmation/', views.contactconfirme, name='contactconfirme'),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
+    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'), name='robots'),
 
     path('auth/', include('social_django.urls', namespace='social')),
     path('accounts/login/', auth_views.LoginView.as_view(), name='login'),

--- a/rusard_site/rusardhome/templates/robots.txt
+++ b/rusard_site/rusardhome/templates/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rusard.ch/sitemap.xml

--- a/rusard_site/rusardhome/templates/rusardhome/about.html
+++ b/rusard_site/rusardhome/templates/rusardhome/about.html
@@ -1,6 +1,9 @@
 {% extends 'rusardhome/base.html' %}
 {% load static %}
 
+{% block title %}À propos - Rusard{% endblock %}
+{% block meta_description %}Page à propos de Rusard et de ses réalisations.{% endblock %}
+
 {% block content %}
 <div class="container bg-light text-center">
     <img class="img-fluid" src="{% static 'rusardhome/media/pageenconstruction.png' %}" alt="">

--- a/rusard_site/rusardhome/templates/rusardhome/accueil.html
+++ b/rusard_site/rusardhome/templates/rusardhome/accueil.html
@@ -1,6 +1,9 @@
 {% extends 'rusardhome/base.html' %}
 {% load static %}
 
+{% block title %}Accueil - Rusard{% endblock %}
+{% block meta_description %}Bienvenue sur Rusard.ch, découvrez toutes mes passions et services.{% endblock %}
+
 {% block content %}
     <div class="main bg-light">
         <div class="container py-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/base.html
+++ b/rusard_site/rusardhome/templates/rusardhome/base.html
@@ -5,7 +5,10 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Rusard</title>
+    <title>{% block title %}Rusard{% endblock %}</title>
+    <meta name="description" content="{% block meta_description %}Site de Rusard{% endblock %}">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{ request.build_absolute_uri }}">
     
     <!-- Favicon standard -->
     <link rel="icon" type="image/png" sizes="96x96" href="{% static 'rusardhome/favicon/favicon-96x96.png' %}">

--- a/rusard_site/rusardhome/templates/rusardhome/contact.html
+++ b/rusard_site/rusardhome/templates/rusardhome/contact.html
@@ -1,5 +1,8 @@
 {% extends 'rusardhome/base.html' %}
 {% load static %}
+
+{% block title %}Contact - Rusard{% endblock %}
+{% block meta_description %}Formulaire de contact pour joindre Rusard.{% endblock %}
 {% block content %}
 <div class="main bg-light">
     <div class="container pt-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/contactconfirme.html
+++ b/rusard_site/rusardhome/templates/rusardhome/contactconfirme.html
@@ -1,5 +1,8 @@
 {% extends 'rusardhome/base.html' %}
 {% load static %}
+
+{% block title %}Message envoyé - Rusard{% endblock %}
+{% block meta_description %}Confirmation d'envoi du message de contact.{% endblock %}
 {% block content %}
 <div class="main bg-light">
     <div class="container pt-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/modelisation.html
+++ b/rusard_site/rusardhome/templates/rusardhome/modelisation.html
@@ -1,5 +1,8 @@
 {% extends 'rusardhome/base.html' %}
 {% load static %}
+
+{% block title %}Modélisation 3D - Rusard{% endblock %}
+{% block meta_description %}Services de modélisation et d'impression 3D proposés par Rusard.{% endblock %}
 {% block content %}
 <div class="main bg-light">
     <div class="container pt-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/projetapp.html
+++ b/rusard_site/rusardhome/templates/rusardhome/projetapp.html
@@ -1,4 +1,7 @@
 {% extends 'rusardhome/base.html' %}
+
+{% block title %}Applications - Rusard{% endblock %}
+{% block meta_description %}Liste des petites applications créées par Rusard.{% endblock %}
 {% block content %}
 
 <div class="main bg-light">

--- a/rusard_site/ts/templates/ts/ts.html
+++ b/rusard_site/ts/templates/ts/ts.html
@@ -5,6 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>APP Tours_de_services</title>
+    <meta name="description" content="Recherche de tours de service par numéro de train">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{ request.build_absolute_uri }}">
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">


### PR DESCRIPTION
## Summary
- add dynamic title & meta description to base template
- define page-specific SEO titles/descriptions
- create robots.txt template and serve via urls
- enhance ts page with canonical link

## Testing
- `flake8 .` *(fails: E501 line too long)*
- `python manage.py test` *(fails: Port could not be cast to integer value as 'None')*

------
https://chatgpt.com/codex/tasks/task_e_686a485c9d74832c80ea6bbe4d8e2d24