### PR TITLE
Add robots.txt and extend sitemap

### DIFF
--- a/rusard_site/rusard_site/urls.py
+++ b/rusard_site/rusard_site/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('Contact/', views.contact, name='contact'),
     path('ts-tpf/', ts_views.tours_services, name='ts'),
     path('Contact/Confirmation/', views.contactconfirme, name='contactconfirme'),
+    path('robots.txt', views.robots_txt, name='robots_txt'),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
 
     path('auth/', include('social_django.urls', namespace='social')),

--- a/rusard_site/rusardhome/sitemaps.py
+++ b/rusard_site/rusardhome/sitemaps.py
@@ -8,7 +8,15 @@ class StaticViewSitemap(Sitemap):
     changefreq = 'monthly'
 
     def items(self):
-        return ['accueil', 'modelisation', 'contact']  # noms des vues `name=` dans urls.py
+        return [
+            'accueil',
+            'modelisation',
+            'contact',
+            'about',
+            'projetapp',
+            'contactconfirme',
+            'ts',
+        ]  # noms des vues `name=` dans urls.py
 
     def location(self, item):
         return reverse(item)

--- a/rusard_site/rusardhome/views.py
+++ b/rusard_site/rusardhome/views.py
@@ -3,6 +3,8 @@ from django.core.mail import send_mail
 from django.conf import settings
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth import login
+from django.http import HttpResponse
+from django.urls import reverse
 
 
 def contactconfirme(request):
@@ -59,3 +61,13 @@ def signup(request):
     else:
         form = UserCreationForm()
     return render(request, 'registration/signup.html', {"form": form})
+
+
+def robots_txt(request):
+    lines = [
+        "User-Agent: *",
+        "Disallow:",
+        f"Sitemap: {request.build_absolute_uri(reverse('django.contrib.sitemaps.views.sitemap'))}",
+    ]
+    return HttpResponse("\n".join(lines), content_type="text/plain")
+


### PR DESCRIPTION
## Summary
- extend `StaticViewSitemap` with all website routes
- serve `robots.txt` dynamically referencing generated sitemap
- wire up `robots.txt` endpoint in URL configuration

## Testing
- `flake8 .. --count`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68691c7fd090832caffe2dc940f09976