### PR TITLE
Improve SEO tags and robots route

### DIFF
--- a/rusard_site/rusard_site/urls.py
+++ b/rusard_site/rusard_site/urls.py
@@ -39,7 +39,6 @@ urlpatterns = [
     path('Contact/', views.contact, name='contact'),
     path('ts-tpf/', ts_views.tours_services, name='ts'),
     path('Contact/Confirmation/', views.contactconfirme, name='contactconfirme'),
-    path('robots.txt', views.robots_txt, name='robots_txt'),
     path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
     path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'), name='robots'),
 

--- a/rusard_site/rusardhome/templates/rusardhome/about.html
+++ b/rusard_site/rusardhome/templates/rusardhome/about.html
@@ -3,6 +3,8 @@
 
 {% block title %}À propos - Rusard{% endblock %}
 {% block meta_description %}Page à propos de Rusard et de ses réalisations.{% endblock %}
+{% block og_title %}À propos - Rusard{% endblock %}
+{% block og_description %}Page à propos de Rusard et de ses réalisations.{% endblock %}
 
 {% block content %}
 <div class="container bg-light text-center">

--- a/rusard_site/rusardhome/templates/rusardhome/accueil.html
+++ b/rusard_site/rusardhome/templates/rusardhome/accueil.html
@@ -3,6 +3,8 @@
 
 {% block title %}Accueil - Rusard{% endblock %}
 {% block meta_description %}Bienvenue sur Rusard.ch, découvrez toutes mes passions et services.{% endblock %}
+{% block og_title %}Accueil - Rusard{% endblock %}
+{% block og_description %}Bienvenue sur Rusard.ch, découvrez toutes mes passions et services.{% endblock %}
 
 {% block content %}
     <div class="main bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/base.html
+++ b/rusard_site/rusardhome/templates/rusardhome/base.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
 
     <meta charset="UTF-8">
@@ -9,6 +9,17 @@
     <meta name="description" content="{% block meta_description %}Site de Rusard{% endblock %}">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="{{ request.build_absolute_uri }}">
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ request.build_absolute_uri }}">
+    <meta property="og:title" content="{% block og_title %}Rusard{% endblock %}">
+    <meta property="og:description" content="{% block og_description %}Site de Rusard{% endblock %}">
+    <meta property="og:image" content="{% block og_image %}{% static 'rusardhome/media/Logo-rusard-2024.png' %}{% endblock %}">
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="{% block og_title %}Rusard{% endblock %}">
+    <meta name="twitter:description" content="{% block og_description %}Site de Rusard{% endblock %}">
+    <meta name="twitter:image" content="{% block og_image %}{% static 'rusardhome/media/Logo-rusard-2024.png' %}{% endblock %}">
     
     <!-- Favicon standard -->
     <link rel="icon" type="image/png" sizes="96x96" href="{% static 'rusardhome/favicon/favicon-96x96.png' %}">

--- a/rusard_site/rusardhome/templates/rusardhome/contact.html
+++ b/rusard_site/rusardhome/templates/rusardhome/contact.html
@@ -3,6 +3,8 @@
 
 {% block title %}Contact - Rusard{% endblock %}
 {% block meta_description %}Formulaire de contact pour joindre Rusard.{% endblock %}
+{% block og_title %}Contact - Rusard{% endblock %}
+{% block og_description %}Formulaire de contact pour joindre Rusard.{% endblock %}
 {% block content %}
 <div class="main bg-light">
     <div class="container pt-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/contactconfirme.html
+++ b/rusard_site/rusardhome/templates/rusardhome/contactconfirme.html
@@ -3,6 +3,8 @@
 
 {% block title %}Message envoyé - Rusard{% endblock %}
 {% block meta_description %}Confirmation d'envoi du message de contact.{% endblock %}
+{% block og_title %}Message envoyé - Rusard{% endblock %}
+{% block og_description %}Confirmation d'envoi du message de contact.{% endblock %}
 {% block content %}
 <div class="main bg-light">
     <div class="container pt-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/modelisation.html
+++ b/rusard_site/rusardhome/templates/rusardhome/modelisation.html
@@ -3,6 +3,8 @@
 
 {% block title %}Modélisation 3D - Rusard{% endblock %}
 {% block meta_description %}Services de modélisation et d'impression 3D proposés par Rusard.{% endblock %}
+{% block og_title %}Modélisation 3D - Rusard{% endblock %}
+{% block og_description %}Services de modélisation et d'impression 3D proposés par Rusard.{% endblock %}
 {% block content %}
 <div class="main bg-light">
     <div class="container pt-5 bg-light">

--- a/rusard_site/rusardhome/templates/rusardhome/projetapp.html
+++ b/rusard_site/rusardhome/templates/rusardhome/projetapp.html
@@ -2,6 +2,8 @@
 
 {% block title %}Applications - Rusard{% endblock %}
 {% block meta_description %}Liste des petites applications créées par Rusard.{% endblock %}
+{% block og_title %}Applications - Rusard{% endblock %}
+{% block og_description %}Liste des petites applications créées par Rusard.{% endblock %}
 {% block content %}
 
 <div class="main bg-light">

--- a/rusard_site/rusardhome/views.py
+++ b/rusard_site/rusardhome/views.py
@@ -63,11 +63,4 @@ def signup(request):
     return render(request, 'registration/signup.html', {"form": form})
 
 
-def robots_txt(request):
-    lines = [
-        "User-Agent: *",
-        "Disallow:",
-        f"Sitemap: {request.build_absolute_uri(reverse('django.contrib.sitemaps.views.sitemap'))}",
-    ]
-    return HttpResponse("\n".join(lines), content_type="text/plain")
 

--- a/rusard_site/ts/templates/ts/ts.html
+++ b/rusard_site/ts/templates/ts/ts.html
@@ -1,6 +1,6 @@
 {% load static %}
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,6 +8,17 @@
     <meta name="description" content="Recherche de tours de service par numéro de train">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="{{ request.build_absolute_uri }}">
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ request.build_absolute_uri }}">
+    <meta property="og:title" content="APP Tours_de_services">
+    <meta property="og:description" content="Recherche de tours de service par numéro de train">
+    <meta property="og:image" content="{% static 'rusardhome/media/Logo-rusard-2024.png' %}">
+    <!-- Twitter -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="APP Tours_de_services">
+    <meta name="twitter:description" content="Recherche de tours de service par numéro de train">
+    <meta name="twitter:image" content="{% static 'rusardhome/media/Logo-rusard-2024.png' %}">
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">


### PR DESCRIPTION
## Summary
- drop unused `robots_txt` view and remove duplicate route
- declare Open Graph/Twitter tags in base template
- update templates to define OG tags
- update `ts` app template and change language tag

## Testing
- `flake8`
- `python manage.py test` *(fails: Port could not be cast to integer)*

------
https://chatgpt.com/codex/tasks/task_e_686a5c3b0f20832c9fb0a2dcac86b46a