### PR TITLE
Add root AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md — site-rusard
+
+This repository's main usage instructions are defined in `rusard_site/agent_pack_site_rusard/AGENTS.md`. That file outlines how ChatGPT agents should work on this project, including:
+
+- Operate without network access.
+- Run the sequence `scripts/format.sh` → `scripts/lint.sh` → `scripts/test.sh` before committing.
+- Avoid modifying secrets and keep changes minimal.
+
+The scripts mentioned above live under `rusard_site/agent_pack_site_rusard/scripts/`.
+
+## Subdirectory AGENTS files
+- `rusard_site/agent_pack_site_rusard/AGENTS.md` — contains the detailed guidelines referenced here.
+- No other subdirectories currently contain an `AGENTS.md`.


### PR DESCRIPTION
## Summary
- Document repository guidelines in new root `AGENTS.md`
- Reference existing agent-pack rules and note absence of other `AGENTS.md` files

## Testing
- `bash agent_pack_site_rusard/scripts/format.sh` (ran from `rusard_site`)
- `bash agent_pack_site_rusard/scripts/lint.sh` (reported ruff warnings)
- `bash agent_pack_site_rusard/scripts/test.sh` *(failed: Port could not be cast to integer value as 'None')*

------
https://chatgpt.com/codex/tasks/task_e_6898a4c9d230832c8be0791a82c15d88