### PR TITLE
Add legal notice and privacy policy pages

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,9 +4,9 @@ import sys
 # Ensure the Django project is importable when running tests locally.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "rusard_site"))
 
-os.environ.setdefault("SECRET_KEY", "testsecret")
+os.environ["SECRET_KEY"] = os.environ.get("SECRET_KEY") or "testsecret"
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE",
-    "rusard_site.rusard_site.settings",
+    "rusard_site.settings",
 )

--- a/logs/2025-02-15-add-legal-pages.log
+++ b/logs/2025-02-15-add-legal-pages.log
@@ -1,0 +1,1 @@
+Added legal notice and privacy policy pages with corresponding views, URLs, templates, and tests.

--- a/rusard_site/rusard_site/urls.py
+++ b/rusard_site/rusard_site/urls.py
@@ -14,37 +14,51 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
-from django.urls import path, include
 from django.contrib.auth import views as auth_views
-import rusardhome.views as views
-import ts.views as ts_views
 from django.contrib.sitemaps.views import sitemap
-from rusardhome.sitemaps import StaticViewSitemap, ArticleSitemap
+from django.urls import include, path
 from django.views.generic import TemplateView
 
+import rusardhome.views as views
+import ts.views as ts_views
+from rusardhome.sitemaps import ArticleSitemap, StaticViewSitemap
 
 sitemaps = {
-    'static': StaticViewSitemap,
-    'articles': ArticleSitemap,
+    "static": StaticViewSitemap,
+    "articles": ArticleSitemap,
 }
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', views.accueil, name='accueil'),
-    path('Accueil/', views.accueil, name='accueil'),
-    path('Modélisation/', views.modelisation, name='modelisation'),
-    path('About/', views.about, name='about'),
-    path('ProjetAPP/', views.projetapp, name='projetapp'),
-    path('Contact/', views.contact, name='contact'),
-    path('ts-tpf/', ts_views.tours_services, name='ts'),
-    path('Contact/Confirmation/', views.contactconfirme, name='contactconfirme'),
-    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
-    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'), name='robots'),
-
-    path('auth/', include('social_django.urls', namespace='social')),
-    path('accounts/login/', auth_views.LoginView.as_view(), name='login'),
-    path('accounts/logout/', auth_views.LogoutView.as_view(), name='logout'),
-    path('accounts/signup/', views.signup, name='signup'),
-
+    path("admin/", admin.site.urls),
+    path("", views.accueil, name="accueil"),
+    path("Accueil/", views.accueil, name="accueil"),
+    path("Modélisation/", views.modelisation, name="modelisation"),
+    path("About/", views.about, name="about"),
+    path("ProjetAPP/", views.projetapp, name="projetapp"),
+    path("Contact/", views.contact, name="contact"),
+    path("ts-tpf/", ts_views.tours_services, name="ts"),
+    path("Contact/Confirmation/", views.contactconfirme, name="contactconfirme"),
+    path("Mentions-legales/", views.mentions_legales, name="mentions_legales"),
+    path(
+        "Politique-de-confidentialite/",
+        views.politique_confidentialite,
+        name="politique_confidentialite",
+    ),
+    path(
+        "sitemap.xml",
+        sitemap,
+        {"sitemaps": sitemaps},
+        name="django.contrib.sitemaps.views.sitemap",
+    ),
+    path(
+        "robots.txt",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+        name="robots",
+    ),
+    path("auth/", include("social_django.urls", namespace="social")),
+    path("accounts/login/", auth_views.LoginView.as_view(), name="login"),
+    path("accounts/logout/", auth_views.LogoutView.as_view(), name="logout"),
+    path("accounts/signup/", views.signup, name="signup"),
 ]

--- a/rusard_site/rusardhome/templates/rusardhome/base.html
+++ b/rusard_site/rusardhome/templates/rusardhome/base.html
@@ -169,8 +169,8 @@
         </nav>
       </div>
       <div class="text-center py-5">
-        <a class="mx-1" href="#Mention légal"><em>Mention légal</em></a>
-        <a class="mx-1" href="#Politique de confidentialité"><em>Politique de confidentialité</em></a>
+        <a class="mx-1" href="{% url 'mentions_legales' %}"><em>Mentions légales</em></a>
+        <a class="mx-1" href="{% url 'politique_confidentialite' %}"><em>Politique de confidentialité</em></a>
       </div>
     </footer>
 

--- a/rusard_site/rusardhome/templates/rusardhome/mentions_legales.html
+++ b/rusard_site/rusardhome/templates/rusardhome/mentions_legales.html
@@ -1,0 +1,21 @@
+{% extends 'rusardhome/base.html' %}
+{% load static %}
+
+{% block title %}Mentions légales - Rusard{% endblock %}
+{% block meta_description %}Mentions légales du site Rusard.{% endblock %}
+{% block og_title %}Mentions légales - Rusard{% endblock %}
+{% block og_description %}Informations légales concernant le site Rusard.{% endblock %}
+
+{% block content %}
+<div class="container bg-light p-4">
+  <h1>Mentions légales</h1>
+  <h2>Éditeur du site</h2>
+  <p>Frédéric Clerc<br>Impasse Garre CFF<br>1782 Belfaux – Suisse<br>Particulier, sans société<br>E-mail : <a href="mailto:contact@rusard.ch">contact@rusard.ch</a></p>
+  <h2>Hébergement</h2>
+  <p>Le site est hébergé par :<br>Frédéric Clerc<br>Impasse Garre CFF<br>1782 Belfaux – Suisse</p>
+  <h2>Propriété intellectuelle</h2>
+  <p>L’ensemble des contenus du site (textes, images, logos, vidéos, etc.) est protégé par le droit d’auteur. Toute reproduction ou représentation, totale ou partielle, sans autorisation préalable est interdite.</p>
+  <h2>Responsabilité</h2>
+  <p>L’éditeur s’efforce de fournir des informations exactes, mais ne peut être tenu responsable des erreurs ou omissions, ni des dommages résultant de l’accès ou de l’utilisation du site.</p>
+</div>
+{% endblock %}

--- a/rusard_site/rusardhome/templates/rusardhome/politique_confidentialite.html
+++ b/rusard_site/rusardhome/templates/rusardhome/politique_confidentialite.html
@@ -1,0 +1,67 @@
+{% extends 'rusardhome/base.html' %}
+{% load static %}
+
+{% block title %}Politique de confidentialité - Rusard{% endblock %}
+{% block meta_description %}Politique de confidentialité du site Rusard.{% endblock %}
+{% block og_title %}Politique de confidentialité - Rusard{% endblock %}
+{% block og_description %}Informations sur la gestion des données personnelles du site Rusard.{% endblock %}
+
+{% block content %}
+<div class="container bg-light p-4">
+  <h1>Politique de confidentialité</h1>
+  <h2>Données personnelles collectées</h2>
+  <ul>
+    <li>Formulaire de contact : nom, prénom, e-mail, message</li>
+    <li>Newsletter : adresse e-mail</li>
+    <li>Cookies et traceurs : techniques, analytiques, marketing</li>
+    <li>Outils de mesure d’audience : Google Analytics</li>
+    <li>Données de paiement : PayPal (en cas de commande)</li>
+    <li>Données de compte client : si inscription ou connexion disponible</li>
+  </ul>
+
+  <h2>Finalités du traitement</h2>
+  <ul>
+    <li>Répondre aux demandes via le formulaire de contact</li>
+    <li>Envoyer des newsletters et communications</li>
+    <li>Mesurer l’audience et améliorer le site</li>
+    <li>Sécuriser le site et prévenir la fraude (Google reCAPTCHA v3)</li>
+    <li>Gérer les comptes clients</li>
+    <li>Traiter les paiements et assurer la facturation (via PayPal)</li>
+  </ul>
+
+  <h2>Bases légales</h2>
+  <ul>
+    <li>Consentement : newsletter, formulaire de contact, cookies marketing</li>
+    <li>Intérêt légitime : statistiques via Google Analytics (données anonymisées)</li>
+    <li>Obligation légale : facturation et obligations comptables liées aux paiements</li>
+    <li>Exécution d’un contrat : gestion des comptes clients, traitement des commandes</li>
+  </ul>
+
+  <h2>Prestataires et services tiers</h2>
+  <ul>
+    <li>Google Analytics : mesure d’audience</li>
+    <li>Google reCAPTCHA v3 : protection contre le spam et les abus</li>
+    <li>PayPal : traitement des paiements</li>
+  </ul>
+
+  <h2>Durée de conservation</h2>
+  <ul>
+    <li>Données de contact : durée nécessaire au traitement de la demande</li>
+    <li>Données de newsletter : jusqu’au désabonnement de l’utilisateur</li>
+    <li>Données de facturation et paiement : conformément aux obligations légales (10 ans en Suisse)</li>
+    <li>Cookies : durée maximale de 13 mois</li>
+  </ul>
+
+  <h2>Droits des utilisateurs</h2>
+  <p>Vous disposez d’un droit d’accès, de rectification, de suppression, d’opposition et de portabilité de vos données personnelles. Pour exercer vos droits : <a href="mailto:contact@rusard.ch">contact@rusard.ch</a></p>
+
+  <h2>Cookies et traceurs</h2>
+  <p>Le site utilise des cookies techniques nécessaires, des cookies analytiques pour mesurer l’audience et, le cas échéant, des cookies marketing. Vous pouvez gérer vos préférences via le bandeau de consentement ou les paramètres de votre navigateur.</p>
+
+  <h2>Sécurité</h2>
+  <p>Des mesures techniques et organisationnelles sont mises en œuvre pour protéger vos données contre les accès non autorisés, les pertes ou les altérations.</p>
+
+  <h2>Modification de la politique</h2>
+  <p>Cette politique de confidentialité peut être mise à jour à tout moment. Les utilisateurs seront informés par une mention sur le site ou par e-mail en cas de modification substantielle.</p>
+</div>
+{% endblock %}

--- a/rusard_site/rusardhome/views.py
+++ b/rusard_site/rusardhome/views.py
@@ -1,67 +1,85 @@
-from django.shortcuts import render, redirect
-from django.core.mail import send_mail
-from django.conf import settings
-from django.contrib.auth.forms import UserCreationForm
-from django.contrib.auth import login
-from django.http import HttpResponse
-from django.urls import reverse
-from django.contrib import messages
 import requests
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth import login
+from django.contrib.auth.forms import UserCreationForm
+from django.core.mail import send_mail
+from django.http import HttpResponse
+from django.shortcuts import redirect, render
+from django.urls import reverse
 
 
 def contactconfirme(request):
-    return render(request, 'rusardhome/contactconfirme.html')
+    return render(request, "rusardhome/contactconfirme.html")
 
 
 def accueil(request):
-    return render(request, 'rusardhome/accueil.html')
+    return render(request, "rusardhome/accueil.html")
 
 
 def modelisation(request):
-    return render(request, 'rusardhome/modelisation.html')
+    return render(request, "rusardhome/modelisation.html")
 
 
 def about(request):
-    return render(request, 'rusardhome/about.html')
+    return render(request, "rusardhome/about.html")
 
 
 def projetapp(request):
-    return render(request, 'rusardhome/projetapp.html')
+    return render(request, "rusardhome/projetapp.html")
+
+
+def mentions_legales(request):
+    return render(request, "rusardhome/mentions_legales.html")
+
+
+def politique_confidentialite(request):
+    return render(request, "rusardhome/politique_confidentialite.html")
 
 
 def contact(request):
-    if request.method == 'POST':
-        name = request.POST.get('name')
-        email = request.POST.get('email')
-        message = request.POST.get('message')
-        honeypot = request.POST.get('website')
+    if request.method == "POST":
+        name = request.POST.get("name")
+        email = request.POST.get("email")
+        message = request.POST.get("message")
+        honeypot = request.POST.get("website")
 
         # Vérification des champs obligatoires
         if not name or not email or not message:
             messages.error(request, "Tous les champs sont obligatoires.")
-            return render(request, 'rusardhome/contact.html', {
-                'recaptcha_site_key': settings.RECAPTCHA_PUBLIC_KEY,
-                'name': name,
-                'email': email,
-                'message': message
-            })
+            return render(
+                request,
+                "rusardhome/contact.html",
+                {
+                    "recaptcha_site_key": settings.RECAPTCHA_PUBLIC_KEY,
+                    "name": name,
+                    "email": email,
+                    "message": message,
+                },
+            )
 
-        recaptcha_response = request.POST.get('g-recaptcha-response')
+        recaptcha_response = request.POST.get("g-recaptcha-response")
         data = {
-            'secret': settings.RECAPTCHA_PRIVATE_KEY,
-            'response': recaptcha_response
+            "secret": settings.RECAPTCHA_PRIVATE_KEY,
+            "response": recaptcha_response,
         }
-        verify = requests.post('https://www.google.com/recaptcha/api/siteverify', data=data)
+        verify = requests.post(
+            "https://www.google.com/recaptcha/api/siteverify", data=data
+        )
         result = verify.json()
         # Vérification du score reCAPTCHA v3
-        if not result.get('success') or result.get('score', 0) < 0.5:
+        if not result.get("success") or result.get("score", 0) < 0.5:
             messages.error(request, "Échec du test reCAPTCHA. Veuillez réessayer.")
-            return render(request, 'rusardhome/contact.html', {
-                'recaptcha_site_key': settings.RECAPTCHA_PUBLIC_KEY,
-                'name': name,
-                'email': email,
-                'message': message
-            })
+            return render(
+                request,
+                "rusardhome/contact.html",
+                {
+                    "recaptcha_site_key": settings.RECAPTCHA_PUBLIC_KEY,
+                    "name": name,
+                    "email": email,
+                    "message": message,
+                },
+            )
 
         full_message = f"Message de {name} ({email}):\n\n{message}"
 
@@ -75,13 +93,17 @@ def contact(request):
             recipient_list=["contact@rusard.ch"],  # ← Ton adresse de réception
         )
 
-        return redirect('contactconfirme')
-    return render(request, 'rusardhome/contact.html', {
-        'recaptcha_site_key': settings.RECAPTCHA_PUBLIC_KEY,
-        'name': '',
-        'email': '',
-        'message': ''
-    })
+        return redirect("contactconfirme")
+    return render(
+        request,
+        "rusardhome/contact.html",
+        {
+            "recaptcha_site_key": settings.RECAPTCHA_PUBLIC_KEY,
+            "name": "",
+            "email": "",
+            "message": "",
+        },
+    )
 
 
 def signup(request):
@@ -91,7 +113,7 @@ def signup(request):
         if form.is_valid():
             user = form.save()
             login(request, user)
-            return redirect('accueil')
+            return redirect("accueil")
     else:
         form = UserCreationForm()
-    return render(request, 'registration/signup.html', {"form": form})
+    return render(request, "registration/signup.html", {"form": form})

--- a/rusard_site/tests/test_views.py
+++ b/rusard_site/tests/test_views.py
@@ -4,6 +4,20 @@ from django.urls import reverse
 
 @pytest.mark.django_db
 def test_accueil_view(client):
-    url = reverse('accueil')
+    url = reverse("accueil")
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_mentions_legales_view(client):
+    url = reverse("mentions_legales")
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_politique_confidentialite_view(client):
+    url = reverse("politique_confidentialite")
     response = client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add Mentions légales and Politique de confidentialité templates
- wire views and URL patterns; link from footer
- ensure test settings and coverage for legal pages

## Testing
- `bash agent_pack_site_rusard/scripts/format.sh`
- `bash agent_pack_site_rusard/scripts/lint.sh` *(reports unused imports in ts app)*
- `DATABASE_URL=sqlite:///db.sqlite3 SECRET_KEY=testsecret bash agent_pack_site_rusard/scripts/test.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a426e0e2d8832c88beeb4a17e9e41e