### PR TITLE
Harden contact form and TS utilities

### DIFF
--- a/rusard_site/rusard_site/checks.py
+++ b/rusard_site/rusard_site/checks.py
@@ -1,0 +1,50 @@
+from django.conf import settings
+from django.core import checks
+
+REQUIRED_CONFIGURATION = (
+    (
+        "EMAIL_HOST_USER",
+        settings.EMAIL_HOST_USER,
+        "rusard.E001",
+        "EMAIL_HOST_USER doit être défini dans l'environnement.",
+    ),
+    (
+        "EMAIL_HOST_PASSWORD",
+        settings.EMAIL_HOST_PASSWORD,
+        "rusard.E002",
+        "EMAIL_HOST_PASSWORD doit être défini dans l'environnement.",
+    ),
+    (
+        "RECAPTCHA_PUBLIC_KEY",
+        settings.RECAPTCHA_PUBLIC_KEY,
+        "rusard.E003",
+        "RECAPTCHA_PUBLIC_KEY doit être défini dans l'environnement.",
+    ),
+    (
+        "RECAPTCHA_PRIVATE_KEY",
+        settings.RECAPTCHA_PRIVATE_KEY,
+        "rusard.E004",
+        "RECAPTCHA_PRIVATE_KEY doit être défini dans l'environnement.",
+    ),
+)
+
+
+@checks.register()
+def required_settings_check(
+    app_configs, **kwargs
+):  # pragma: no cover - signature enforced by Django
+    errors: list[checks.CheckMessage] = []
+
+    for name, value, error_id, message in REQUIRED_CONFIGURATION:
+        if not value:
+            errors.append(checks.Critical(message, id=error_id))
+
+    if not settings.DEFAULT_FROM_EMAIL:
+        errors.append(
+            checks.Critical(
+                "DEFAULT_FROM_EMAIL n'est pas défini. Configurez EMAIL_HOST_USER.",
+                id="rusard.E005",
+            )
+        )
+
+    return errors

--- a/rusard_site/rusard_site/settings.py
+++ b/rusard_site/rusard_site/settings.py
@@ -9,11 +9,13 @@ https://docs.djangoproject.com/en/dev/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/dev/ref/settings/
 """
-import os
-import dj_database_url
-from pathlib import Path
-import urllib.parse
 
+import os
+import re
+import urllib.parse
+from pathlib import Path
+
+import dj_database_url
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -26,74 +28,81 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DEBUG', '0') == '1'
+DEBUG = os.environ.get("DEBUG", "0") == "1"
 
-ALLOWED_HOSTS = os.getenv("DJANGO_ALLOWED_HOSTS", "").split(",")
+
+def parse_env_list(variable_name: str) -> list[str]:
+    raw_value = os.environ.get(variable_name, "")
+    if not raw_value:
+        return []
+    parts = re.split(r"[\s,]+", raw_value.strip())
+    return [item for item in parts if item]
+
+
+ALLOWED_HOSTS = parse_env_list("DJANGO_ALLOWED_HOSTS")
 
 # Application definition
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'fontawesomefree',
-    'rusardhome',
-    'ts',
-    'django.contrib.sitemaps',
-    'social_django',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "fontawesomefree",
+    "rusardhome",
+    "ts",
+    "django.contrib.sitemaps",
+    "social_django",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
 # Authentication backends for social auth
 AUTHENTICATION_BACKENDS = [
-    'social_core.backends.google.GoogleOAuth2',
-    'social_core.backends.facebook.FacebookOAuth2',
-    'social_core.backends.twitch.TwitchOAuth2',
-    'django.contrib.auth.backends.ModelBackend',
+    "social_core.backends.google.GoogleOAuth2",
+    "social_core.backends.facebook.FacebookOAuth2",
+    "social_core.backends.twitch.TwitchOAuth2",
+    "django.contrib.auth.backends.ModelBackend",
 ]
 
-ROOT_URLCONF = 'rusard_site.urls'
+ROOT_URLCONF = "rusard_site.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-                'social_django.context_processors.backends',
-                'social_django.context_processors.login_redirect',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "social_django.context_processors.backends",
+                "social_django.context_processors.login_redirect",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'rusard_site.wsgi.application'
+WSGI_APPLICATION = "rusard_site.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
 DATABASES = {
-    'default': dj_database_url.config(
+    "default": dj_database_url.config(
         default=f"postgres://{urllib.parse.quote(os.environ.get('SQL_USER', ''))}:{urllib.parse.quote(os.environ.get('SQL_PASSWORD', ''))}@{os.environ.get('SQL_HOST')}:{os.environ.get('SQL_PORT')}/{os.environ.get('SQL_DATABASE')}"
     )
 }
@@ -104,16 +113,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -121,9 +130,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/dev/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -133,18 +142,20 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/dev/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"
 # Indiquer où les fichiers statiques seront collectés (cela doit être dans un répertoire accessible par Nginx)
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')  # Exemple : /home/app/web/staticfiles
+STATIC_ROOT = os.path.join(
+    BASE_DIR, "staticfiles"
+)  # Exemple : /home/app/web/staticfiles
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-CSRF_TRUSTED_ORIGINS = os.environ.get("CSRF_TRUSTED_ORIGINS", "").split()
+CSRF_TRUSTED_ORIGINS = parse_env_list("CSRF_TRUSTED_ORIGINS")
 
 # Configuration mail
 
@@ -154,20 +165,25 @@ EMAIL_PORT = 465
 EMAIL_USE_SSL = True
 EMAIL_USE_TLS = False
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")  # ← Ton adresse email
-EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")  # ← Mot de passe d'application sécurisé
+EMAIL_HOST_PASSWORD = os.environ.get(
+    "EMAIL_HOST_PASSWORD"
+)  # ← Mot de passe d'application sécurisé
 DEFAULT_FROM_EMAIL = EMAIL_HOST_USER
 
 # Login and logout redirects
-LOGIN_URL = 'login'
-LOGIN_REDIRECT_URL = 'accueil'
-LOGOUT_REDIRECT_URL = 'accueil'
+LOGIN_URL = "login"
+LOGIN_REDIRECT_URL = "accueil"
+LOGOUT_REDIRECT_URL = "accueil"
 
 # Social auth keys (set in environment variables)
-SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
-SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET')
-SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY')
-SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
-SOCIAL_AUTH_TWITCH_KEY = os.environ.get('SOCIAL_AUTH_TWITCH_KEY')
-SOCIAL_AUTH_TWITCH_SECRET = os.environ.get('SOCIAL_AUTH_TWITCH_SECRET')
-RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY')
-RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_KEY")
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get("SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET")
+SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get("SOCIAL_AUTH_FACEBOOK_KEY")
+SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get("SOCIAL_AUTH_FACEBOOK_SECRET")
+SOCIAL_AUTH_TWITCH_KEY = os.environ.get("SOCIAL_AUTH_TWITCH_KEY")
+SOCIAL_AUTH_TWITCH_SECRET = os.environ.get("SOCIAL_AUTH_TWITCH_SECRET")
+RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY")
+RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY")
+
+
+from . import checks  # noqa: F401,E402

--- a/rusard_site/rusardhome/admin.py
+++ b/rusard_site/rusardhome/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
-# Register your models here.
+"""Admin registrations for rusardhome."""

--- a/rusard_site/rusardhome/forms.py
+++ b/rusard_site/rusardhome/forms.py
@@ -1,0 +1,47 @@
+from django import forms
+
+
+class ContactForm(forms.Form):
+    firstname = forms.CharField(
+        label="Prénom",
+        max_length=150,
+    )
+    name = forms.CharField(
+        label="Nom",
+        max_length=150,
+    )
+    email = forms.EmailField(
+        label="Email",
+        max_length=254,
+    )
+    message = forms.CharField(
+        label="Message",
+        widget=forms.Textarea,
+        max_length=2000,
+    )
+    website = forms.CharField(
+        required=False,
+        label="Site web",
+        widget=forms.TextInput,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field_name, field in self.fields.items():
+            if field_name != "website":
+                classes = field.widget.attrs.get("class", "")
+                field.widget.attrs["class"] = f"form-control {classes}".strip()
+            if field_name == "message":
+                field.widget.attrs.setdefault("rows", 4)
+
+        # Honeypot should remain invisible but accessible to screen readers
+        website_widget = self.fields["website"].widget
+        website_widget.attrs.setdefault("autocomplete", "off")
+        website_widget.attrs.setdefault("tabindex", "-1")
+        website_widget.attrs.setdefault("aria-hidden", "true")
+
+    def clean_website(self):
+        website = self.cleaned_data.get("website", "").strip()
+        if website:
+            raise forms.ValidationError("Le formulaire n'a pas pu être envoyé.")
+        return website

--- a/rusard_site/rusardhome/templates/rusardhome/contact.html
+++ b/rusard_site/rusardhome/templates/rusardhome/contact.html
@@ -20,25 +20,37 @@
             <form id="contact-form" method="post" class="row px-4">
                 {% csrf_token %}
                 <div class="col-6 my-2">
-                    <label for="firstname" class="form-label">Prénom</label>
-                    <input name="firstname" type="text" class="form-control" id="firstname" required>
+                    <label for="{{ form.firstname.id_for_label }}" class="form-label">{{ form.firstname.label }}</label>
+                    {{ form.firstname }}
+                    {% if form.firstname.errors %}
+                        <div class="text-danger small mt-1">{{ form.firstname.errors|join:', ' }}</div>
+                    {% endif %}
                 </div>
                 <div class="col-6 my-2">
-                    <label for="name" class="form-label">Nom</label>
-                    <input name="name" type="text" class="form-control" id="name" required value="{{ name|default:'' }}">
+                    <label for="{{ form.name.id_for_label }}" class="form-label">{{ form.name.label }}</label>
+                    {{ form.name }}
+                    {% if form.name.errors %}
+                        <div class="text-danger small mt-1">{{ form.name.errors|join:', ' }}</div>
+                    {% endif %}
                 </div>
                 <div class="col-12 my-2">
-                    <label for="email" class="form-label">Email address</label>
-                    <input name="email" type="email" class="form-control" id="email" required value="{{ email|default:'' }}">
+                    <label for="{{ form.email.id_for_label }}" class="form-label">{{ form.email.label }}</label>
+                    {{ form.email }}
+                    {% if form.email.errors %}
+                        <div class="text-danger small mt-1">{{ form.email.errors|join:', ' }}</div>
+                    {% endif %}
                 </div>
                 <div class="col-12 my-2">
-                    <label for="message" class="form-label">Message</label>
-                    <textarea name="message" class="form-control" id="message" rows="3" required>{{ message|default:'' }}</textarea>
+                    <label for="{{ form.message.id_for_label }}" class="form-label">{{ form.message.label }}</label>
+                    {{ form.message }}
+                    {% if form.message.errors %}
+                        <div class="text-danger small mt-1">{{ form.message.errors|join:', ' }}</div>
+                    {% endif %}
                 </div>
-                 <!-- Honeypot invisible -->
-                <div style="display:none;">
-                    <label for="website">Ne pas remplir ce champ</label>
-                    <input type="text" name="website" id="website">
+                <!-- Honeypot invisible -->
+                <div class="d-none">
+                    <label for="{{ form.website.id_for_label }}">{{ form.website.label }}</label>
+                    {{ form.website }}
                 </div>
                 <!-- Submit button -->
                 <div class="col-12 my-2">

--- a/rusard_site/rusardhome/tests_placeholder.py
+++ b/rusard_site/rusardhome/tests_placeholder.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
-# Create your tests here.
+"""Placeholder for rusardhome tests."""

--- a/rusard_site/tests/test_contact.py
+++ b/rusard_site/tests/test_contact.py
@@ -1,0 +1,112 @@
+import pytest
+import requests
+from django.urls import reverse
+
+
+@pytest.fixture
+def recaptcha_success(monkeypatch):
+    class DummyResponse:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self._payload
+
+    def fake_post(url, data=None, timeout=None):
+        assert url == "https://www.google.com/recaptcha/api/siteverify"
+        assert timeout == 5
+        return DummyResponse({"success": True, "score": 0.9})
+
+    monkeypatch.setattr("rusardhome.views.requests.post", fake_post)
+
+
+@pytest.mark.django_db
+def test_contact_form_success(client, settings, recaptcha_success, monkeypatch):
+    settings.RECAPTCHA_PRIVATE_KEY = "private"
+    settings.RECAPTCHA_PUBLIC_KEY = "public"
+    settings.DEFAULT_FROM_EMAIL = "from@example.com"
+
+    sent = {}
+
+    def fake_send_mail(*args, **kwargs):
+        sent["called"] = True
+        return 1
+
+    monkeypatch.setattr("rusardhome.views.send_mail", fake_send_mail)
+
+    response = client.post(
+        reverse("contact"),
+        data={
+            "firstname": "Jean",
+            "name": "Dupont",
+            "email": "jean.dupont@example.com",
+            "message": "Bonjour",
+            "g-recaptcha-response": "token",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse("contactconfirme")
+    assert sent.get("called") is True
+
+
+@pytest.mark.django_db
+def test_contact_form_honeypot_blocks_send(
+    client, settings, recaptcha_success, monkeypatch
+):
+    settings.RECAPTCHA_PRIVATE_KEY = "private"
+    settings.RECAPTCHA_PUBLIC_KEY = "public"
+    settings.DEFAULT_FROM_EMAIL = "from@example.com"
+
+    def fake_send_mail(*args, **kwargs):  # pragma: no cover - safety net
+        raise AssertionError("send_mail ne devrait pas être appelé")
+
+    monkeypatch.setattr("rusardhome.views.send_mail", fake_send_mail)
+
+    response = client.post(
+        reverse("contact"),
+        data={
+            "firstname": "Jean",
+            "name": "Dupont",
+            "email": "jean.dupont@example.com",
+            "message": "Bonjour",
+            "website": "bot",
+            "g-recaptcha-response": "token",
+        },
+    )
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Le formulaire contient des erreurs." in content
+
+
+@pytest.mark.django_db
+def test_contact_form_recaptcha_network_error(client, settings, monkeypatch):
+    settings.RECAPTCHA_PRIVATE_KEY = "private"
+    settings.RECAPTCHA_PUBLIC_KEY = "public"
+    settings.DEFAULT_FROM_EMAIL = "from@example.com"
+
+    def fake_post(*args, **kwargs):
+        raise requests.RequestException()
+
+    monkeypatch.setattr("rusardhome.views.requests.post", fake_post)
+
+    response = client.post(
+        reverse("contact"),
+        data={
+            "firstname": "Jean",
+            "name": "Dupont",
+            "email": "jean.dupont@example.com",
+            "message": "Bonjour",
+            "g-recaptcha-response": "token",
+        },
+    )
+
+    assert response.status_code == 200
+    assert (
+        "Le service de vérification est momentanément indisponible"
+        in response.content.decode()
+    )

--- a/rusard_site/tests/test_ts.py
+++ b/rusard_site/tests/test_ts.py
@@ -1,0 +1,41 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_tours_services_success(client):
+    response = client.post(
+        reverse("ts"),
+        data={"train_number": "14267", "period": "Lundi-Jeudi"},
+    )
+
+    assert response.status_code == 200
+    assert "Effectué par Ts4551" in response.content.decode()
+
+    session = client.session
+    history = session.get("ts_history")
+    assert history
+    assert history[0]["train_number"] == 14267
+    assert history[0]["tour"] == "Ts4551"
+
+
+@pytest.mark.django_db
+def test_tours_services_invalid_number(client):
+    response = client.post(
+        reverse("ts"),
+        data={"train_number": "abc", "period": "Lundi-Jeudi"},
+    )
+
+    assert response.status_code == 200
+    assert "Numéro de train invalide" in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_tours_services_unknown_train(client):
+    response = client.post(
+        reverse("ts"),
+        data={"train_number": "99999", "period": "Vendredi"},
+    )
+
+    assert response.status_code == 200
+    assert "Train non trouvé" in response.content.decode()

--- a/rusard_site/ts/admin.py
+++ b/rusard_site/ts/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
-# Register your models here.
+"""Admin registrations for the ts app."""

--- a/rusard_site/ts/models.py
+++ b/rusard_site/ts/models.py
@@ -1,4 +1,1 @@
-from django.db import models
-
-
-# Create your models here.
+"""Data models for the ts app."""

--- a/rusard_site/ts/templates/ts/ts.html
+++ b/rusard_site/ts/templates/ts/ts.html
@@ -1,86 +1,68 @@
+{% extends 'rusardhome/base.html' %}
 {% load static %}
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>APP Tours_de_services</title>
-    <meta name="description" content="Recherche de tours de service par numéro de train">
-    <meta name="robots" content="index, follow">
-    <link rel="canonical" href="{{ request.build_absolute_uri }}">
-    <!-- Open Graph -->
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ request.build_absolute_uri }}">
-    <meta property="og:title" content="APP Tours_de_services">
-    <meta property="og:description" content="Recherche de tours de service par numéro de train">
-    <meta property="og:image" content="{% static 'rusardhome/media/Logo-rusard-2024.png' %}">
 
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css">
-</head>
-<body>
-    <div class="container">
-        <h1>Recherche de Tours de Service</h1>
-        <p>J'ai créé cette application dans le but de trouver plus rapidement le numero du tours qui fais un certain train. </p>
-        <p>Elle se base uniquement sur les consignes diponible dans Intera.</p>
-        <div class="container mt-2">
-            <form method="post">
-                {% csrf_token %}
-                
-                <!-- Numéro de train -->
-                <div class="form-group">
-                    <label for="train_number"><strong>Numéro de train :</strong></label>
-                    <input type="text" class="form-control" id="train_number" name="train_number" placeholder="Entrez le numéro de train" required>
-                </div>
-    
-                <!-- Boutons radio pour sélectionner la période -->
-                <div class="form-group">
-                    <label><strong>Période de roulement :</strong></label>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" name="period" id="period1" value="Lundi-Jeudi" required>
-                        <label class="form-check-label" for="period1">
-                            Lundi-Jeudi
-                        </label>
-                    </div>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" name="period" id="period2" value="Vendredi" required>
-                        <label class="form-check-label" for="period2">
-                            Vendredi
-                        </label>
-                    </div>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" name="period" id="period3" value="Samedi" required>
-                        <label class="form-check-label" for="period3">
-                            Samedi
-                        </label>
-                    </div>
-                    <div class="form-check">
-                        <input class="form-check-input" type="radio" name="period" id="period4" value="Dimanche" required>
-                        <label class="form-check-label" for="period4">
-                            Dimanche
-                        </label>
-                    </div>
-                </div>
-    
-                <!-- Bouton de soumission -->
+{% block title %}Tours de service - Rusard{% endblock %}
+{% block meta_description %}Recherche de tours de service par numéro de train{% endblock %}
+{% block og_title %}Tours de service - Rusard{% endblock %}
+{% block og_description %}Recherche de tours de service par numéro de train{% endblock %}
+
+{% block content %}
+<div class="container py-5">
+    <h1 class="display-5">Recherche de Tours de Service</h1>
+    <p>J'ai créé cette application dans le but de trouver plus rapidement le numéro du tour qui effectue un certain train.</p>
+    <p>Elle se base uniquement sur les consignes disponibles dans Intera.</p>
+    <div class="bg-light rounded p-4 shadow-sm">
+        <form method="post" class="row g-3">
+            {% csrf_token %}
+
+            <div class="col-md-6">
+                <label for="train_number" class="form-label"><strong>Numéro de train :</strong></label>
+                <input type="text" class="form-control" id="train_number" name="train_number" placeholder="Entrez le numéro de train" required value="{{ train_number }}">
+            </div>
+
+            <div class="col-md-6">
+                <fieldset>
+                    <legend class="fs-6"><strong>Période de roulement :</strong></legend>
+                    {% for value, label in period_choices %}
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="period" id="period-{{ forloop.counter }}" value="{{ value }}" required {% if period == value %}checked{% endif %}>
+                            <label class="form-check-label" for="period-{{ forloop.counter }}">{{ label }}</label>
+                        </div>
+                    {% endfor %}
+                </fieldset>
+            </div>
+
+            <div class="col-12">
                 <button type="submit" class="btn btn-primary">Soumettre</button>
-            </form>
-    
-            <!-- Zone d'affichage des résultats ou des erreurs -->
-            {% if result %}
-                <div class="alert alert-success mt-4">
-                    {{ result }}
-                </div>
-            {% elif error %}
-                <div class="alert alert-danger mt-4">
-                    {{ error }}
-                </div>
-            {% endif %}
-        </div>
+            </div>
+        </form>
+
+        {% if result %}
+            <div class="alert alert-success mt-4" role="status">
+                {{ result }}
+            </div>
+        {% elif error %}
+            <div class="alert alert-danger mt-4" role="alert">
+                {{ error }}
+            </div>
+        {% endif %}
     </div>
-    <script>
-        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
-    </script>
-</body>
-</html>
+
+    {% if history %}
+        <div class="mt-4">
+            <h2 class="h4">Historique récent</h2>
+            <p class="text-muted">Les cinq dernières recherches réussies.</p>
+            <ul class="list-group">
+                {% for item in history %}
+                    <li class="list-group-item d-flex justify-content-between align-items-center">
+                        <span>
+                            <strong>Train {{ item.train_number }}</strong> — {{ item.period }}
+                        </span>
+                        <span class="badge bg-primary rounded-pill">{{ item.tour }}</span>
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/rusard_site/ts/tests_placeholder.py
+++ b/rusard_site/ts/tests_placeholder.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
-# Create your tests here.
+"""Placeholder for ts app tests."""

--- a/rusard_site/ts/views.py
+++ b/rusard_site/ts/views.py
@@ -1,34 +1,89 @@
+import logging
+
 from django.shortcuts import render
-from django.http import HttpResponse
 from ts.data import data
+
+logger = logging.getLogger(__name__)
+
+HISTORY_SESSION_KEY = "ts_history"
+PERIOD_CHOICES = (
+    ("Lundi-Jeudi", "Lundi-Jeudi"),
+    ("Vendredi", "Vendredi"),
+    ("Samedi", "Samedi"),
+    ("Dimanche", "Dimanche"),
+)
 
 
 # Create your views here.
 
 
 def tours_services(request):
-    if request.method == 'POST':
-        train_number = request.POST.get('train_number')
-        period = request.POST.get('period')
+    context = {
+        "history": request.session.get(HISTORY_SESSION_KEY, []),
+        "train_number": "",
+        "period": "",
+        "period_choices": PERIOD_CHOICES,
+    }
 
-        if not train_number:
-            return render(request, 'ts/ts.html', {'error': 'Veuillez entrer un numéro de train.'})
+    if request.method == "POST":
+        train_number_raw = request.POST.get("train_number", "").strip()
+        period = request.POST.get("period", "").strip()
+
+        context.update(
+            {
+                "train_number": train_number_raw,
+                "period": period,
+            }
+        )
+
+        if not train_number_raw:
+            context["error"] = "Veuillez entrer un numéro de train."
+            return render(request, "ts/ts.html", context)
 
         if not period:
-            return render(request, 'ts/ts.html', {'error': 'Veuillez choisir une période de roulement.'})
+            context["error"] = "Veuillez choisir une période de roulement."
+            return render(request, "ts/ts.html", context)
 
         try:
-            train_number = int(train_number)
+            train_number = int(train_number_raw)
         except ValueError:
-            return render(request, 'ts/ts.html', {'error': 'Numéro de train invalide. Veuillez entrer un nombre entier.'})
-
+            context["error"] = (
+                "Numéro de train invalide. Veuillez entrer un nombre entier."
+            )
+            return render(request, "ts/ts.html", context)
 
         for tour, trains in data.get(period, {}).items():
             if train_number in trains:
                 result = f"N° {train_number} - Effectué par {tour}"
-                return render(request, 'ts/ts.html', {'result': result})
+                context["result"] = result
 
-        return render(request, 'ts/ts.html', {'error': 'Train non trouvé dans cette période.'})
+                history = [
+                    {
+                        "train_number": train_number,
+                        "period": period,
+                        "tour": tour,
+                    }
+                ]
+                history.extend(request.session.get(HISTORY_SESSION_KEY, []))
+                request.session[HISTORY_SESSION_KEY] = history[:5]
+                request.session.modified = True
 
-    return render(request, 'ts/ts.html')
+                logger.info(
+                    "Consultation de tour de service",
+                    extra={
+                        "train_number": train_number,
+                        "period": period,
+                        "tour": tour,
+                    },
+                )
 
+                context["history"] = request.session[HISTORY_SESSION_KEY]
+                return render(request, "ts/ts.html", context)
+
+        logger.info(
+            "Train non trouvé", extra={"train_number": train_number, "period": period}
+        )
+        context["error"] = "Train non trouvé dans cette période."
+        return render(request, "ts/ts.html", context)
+
+    return render(request, "ts/ts.html", context)


### PR DESCRIPTION
## Summary
- introduce server-side form validation, error handling and logging for the contact form
- add configuration helpers and system checks to guard required environment settings
- modernize the tours de service page with shared layout, search history and new regression tests

## Testing
- `bash rusard_site/agent_pack_site_rusard/scripts/format.sh`
- `bash rusard_site/agent_pack_site_rusard/scripts/lint.sh`
- `(cd rusard_site && DATABASE_URL=sqlite:///db.sqlite3 EMAIL_HOST_USER=test@example.com EMAIL_HOST_PASSWORD=secret RECAPTCHA_PUBLIC_KEY=dummy RECAPTCHA_PRIVATE_KEY=dummy SECRET_KEY=testsecret bash agent_pack_site_rusard/scripts/test.sh)`

------
https://chatgpt.com/codex/tasks/task_e_68d3b9df35bc832caf8a3bd0cfb86530