### PR TITLE
Fix nginx proxy certificate automation

### DIFF
--- a/.env.prod.proxy-companion
+++ b/.env.prod.proxy-companion
@@ -1,3 +1,4 @@
 DEFAULT_EMAIL=contact@rusard.ch
 ACME_CA_URI=https://acme-v02.api.letsencrypt.org/directory
 NGINX_PROXY_CONTAINER=nginx-proxy
+NGINX_DOCKER_GEN_CONTAINER=docker-gen

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Développer un site vitrine professionnel avec des fonctionnalités comme :
 * **Backend** : [Django](https://www.djangoproject.com/)
 * **Base de données** : PostgreSQL
 * **Serveur web** : Gunicorn + Nginx
-* **Reverse Proxy** : nginx-proxy + acme-companion (Let's Encrypt)
+* **Reverse Proxy** : nginx-proxy + docker-gen + acme-companion (Let's Encrypt)
 * **Conteneurs** : Docker + Docker Compose
 * **CI/CD** : GitHub Actions
 * **Environnement Dev/Prod** : géré via `.env` + `Dockerfile` multi-stage

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -47,6 +47,23 @@ services:
     depends_on:
       - web
 
+  docker-gen:
+    image: nginxproxy/docker-gen
+    container_name: docker-gen
+    restart: always
+    command: >-
+      -notify-sighup nginx-proxy
+      -watch
+      -wait 5s:30s
+      /etc/docker-gen/templates/nginx.tmpl
+      /etc/nginx/conf.d/default.conf
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+    volumes_from:
+      - nginx-proxy
+    depends_on:
+      - nginx-proxy
+
   acme-companion:
     image: nginxproxy/acme-companion
     env_file:
@@ -58,7 +75,7 @@ services:
       - vhost:/etc/nginx/vhost.d
       - acme:/etc/acme.sh
     depends_on:
-      - nginx-proxy
+      - docker-gen
 
 volumes:
   postgres_data:

--- a/logs/2025-03-15-fix-nginx-acme.log
+++ b/logs/2025-03-15-fix-nginx-acme.log
@@ -1,0 +1,1 @@
+Added docker-gen sidecar to the production stack so nginx-proxy rebuilds virtual hosts, wired acme-companion to the new container, and documented the change.


### PR DESCRIPTION
## Summary
- add a dedicated docker-gen sidecar so nginx-proxy regenerates virtual hosts
- teach the acme companion about the docker-gen container and document the updated proxy stack
- record the troubleshooting steps in the agent logs directory

## Testing
- ./rusard_site/agent_pack_site_rusard/scripts/format.sh
- ./rusard_site/agent_pack_site_rusard/scripts/lint.sh
- ./rusard_site/agent_pack_site_rusard/scripts/test.sh *(fails: pytest lacks Django integration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4885700f8832cbe4d0cc3212dbd79