### PR TITLE
Fix local startup defaults for required env settings

### DIFF
--- a/rusard_site/rusard_site/checks.py
+++ b/rusard_site/rusard_site/checks.py
@@ -1,3 +1,5 @@
+import os
+
 from django.conf import settings
 from django.core import checks
 
@@ -28,23 +30,49 @@ REQUIRED_CONFIGURATION = (
     ),
 )
 
+PLACEHOLDERS = getattr(settings, "REQUIRED_SETTINGS_PLACEHOLDERS", {})
+
+
+def _uses_placeholder(name: str, value: str) -> bool:
+    placeholder = PLACEHOLDERS.get(name)
+    return bool(placeholder) and value == placeholder
+
 
 @checks.register()
 def required_settings_check(
     app_configs, **kwargs
 ):  # pragma: no cover - signature enforced by Django
-    errors: list[checks.CheckMessage] = []
+    messages: list[checks.CheckMessage] = []
 
     for name, value, error_id, message in REQUIRED_CONFIGURATION:
-        if not value:
-            errors.append(checks.Critical(message, id=error_id))
+        env_value = os.environ.get(name)
+        if env_value:
+            continue
+        if _uses_placeholder(name, value):
+            messages.append(
+                checks.Warning(
+                    f"{message} Une valeur de substitution de développement est utilisée.",
+                    id=f"{error_id}.placeholder",
+                )
+            )
+        else:
+            messages.append(checks.Critical(message, id=error_id))
 
     if not settings.DEFAULT_FROM_EMAIL:
-        errors.append(
+        messages.append(
             checks.Critical(
                 "DEFAULT_FROM_EMAIL n'est pas défini. Configurez EMAIL_HOST_USER.",
                 id="rusard.E005",
             )
         )
+    elif _uses_placeholder(
+        "EMAIL_HOST_USER", settings.DEFAULT_FROM_EMAIL
+    ) and not os.environ.get("EMAIL_HOST_USER"):
+        messages.append(
+            checks.Warning(
+                "DEFAULT_FROM_EMAIL utilise une valeur de substitution. Définissez EMAIL_HOST_USER pour la production.",
+                id="rusard.E005.placeholder",
+            )
+        )
 
-    return errors
+    return messages

--- a/rusard_site/tests/test_checks.py
+++ b/rusard_site/tests/test_checks.py
@@ -1,0 +1,29 @@
+from django.core import checks as django_checks
+
+from rusard_site import checks
+
+
+def test_required_settings_check_warns_when_using_placeholders(monkeypatch):
+    for key in [
+        "EMAIL_HOST_USER",
+        "EMAIL_HOST_PASSWORD",
+        "RECAPTCHA_PUBLIC_KEY",
+        "RECAPTCHA_PRIVATE_KEY",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    messages = checks.required_settings_check(None)
+
+    assert not any(isinstance(message, django_checks.Critical) for message in messages)
+
+    warning_ids = {
+        message.id for message in messages if isinstance(message, django_checks.Warning)
+    }
+
+    assert {
+        "rusard.E001.placeholder",
+        "rusard.E002.placeholder",
+        "rusard.E003.placeholder",
+        "rusard.E004.placeholder",
+        "rusard.E005.placeholder",
+    }.issubset(warning_ids)

--- a/rusard_site/tests/test_settings.py
+++ b/rusard_site/tests/test_settings.py
@@ -1,0 +1,31 @@
+import pytest
+
+from rusard_site import settings
+
+
+@pytest.mark.parametrize(
+    "env_key",
+    ["SQL_USER", "SQL_PASSWORD", "SQL_HOST", "SQL_PORT", "SQL_DATABASE"],
+)
+def test_build_default_database_url_handles_missing_env(monkeypatch, env_key):
+    monkeypatch.delenv(env_key, raising=False)
+
+    url = settings.build_default_database_url()
+
+    assert "None" not in url
+
+
+def test_build_default_database_url_uses_expected_defaults(monkeypatch):
+    for key in [
+        "SQL_USER",
+        "SQL_PASSWORD",
+        "SQL_HOST",
+        "SQL_PORT",
+        "SQL_DATABASE",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+
+    assert (
+        settings.build_default_database_url()
+        == "postgres://postgres:postgres@localhost:5432/postgres"
+    )


### PR DESCRIPTION
## Summary
- add helper defaults in settings so the app can boot locally without mandatory env vars
- soften configuration checks to warn when development placeholders are used
- cover the new helpers and warnings with pytest-based regression tests

## Testing
- `rusard_site/agent_pack_site_rusard/scripts/format.sh`
- `rusard_site/agent_pack_site_rusard/scripts/lint.sh`
- `python manage.py check`
- `rusard_site/agent_pack_site_rusard/scripts/test.sh` *(fails: manage.py not at repo root)*
- `pytest -q` *(fails: django apps not loaded without pytest-django setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e4aa03c39c832ca734fbd7a12860b0