### PR TITLE
Fix HTTPS redirect loop for rusard.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Le déploiement :
 * Collecte les fichiers statiques
 * Applique les éventuelles migrations
 
+### 🌍 Variables d'environnement clés (production)
+
+Pour éviter les boucles de redirection et servir le domaine canonique, assure-toi que le fichier `.env.prod` contient :
+
+```env
+DJANGO_ALLOWED_HOSTS=rusard.ch,www.rusard.ch
+CSRF_TRUSTED_ORIGINS=https://rusard.ch https://www.rusard.ch
+DJANGO_SECURE_SSL_REDIRECT=1
+```
+
+Les valeurs peuvent être séparées par des virgules ou des espaces : le helper `parse_env_list` se charge de les normaliser.
+
 ## 📩 Contact
 
 Pour toute question ou suggestion :

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
     env_file:
       - ./.env.prod
     environment:
-      - VIRTUAL_HOST=rusard.ch
+      - VIRTUAL_HOST=rusard.ch,www.rusard.ch
       - VIRTUAL_PORT=8000
       - LETSENCRYPT_HOST=rusard.ch,www.rusard.ch
       - LETSENCRYPT_EMAIL=contact@rusard.ch

--- a/nginx/vhost.d/www.rusard.ch
+++ b/nginx/vhost.d/www.rusard.ch
@@ -1,7 +1,1 @@
-location /static/ {
-    alias /home/app/web/staticfiles/;
-}
-
-location /media/ {
-    alias /home/app/web/mediafiles/;
-}
+return 301 https://rusard.ch$request_uri;

--- a/rusard_site/rusard_site/settings.py
+++ b/rusard_site/rusard_site/settings.py
@@ -39,6 +39,13 @@ def parse_env_list(variable_name: str) -> list[str]:
     return [item for item in parts if item]
 
 
+def get_env_flag(variable_name: str, default: bool) -> bool:
+    raw_value = os.environ.get(variable_name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 ALLOWED_HOSTS = parse_env_list("DJANGO_ALLOWED_HOSTS")
 
 
@@ -185,6 +192,8 @@ STATIC_ROOT = os.path.join(
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+SECURE_SSL_REDIRECT = get_env_flag("DJANGO_SECURE_SSL_REDIRECT", default=not DEBUG)
 
 CSRF_TRUSTED_ORIGINS = parse_env_list("CSRF_TRUSTED_ORIGINS")
 


### PR DESCRIPTION
## Summary
- configure the production web container to advertise both rusard.ch and www.rusard.ch to nginx-proxy
- add a canonical redirect at nginx level so www traffic rewrites to https://rusard.ch
- harden Django settings to respect forwarded headers and allow SECURE_SSL_REDIRECT to be toggled via environment
- document the required production environment variables for canonical HTTPS routing

## Testing
- ./rusard_site/agent_pack_site_rusard/scripts/format.sh
- ./rusard_site/agent_pack_site_rusard/scripts/lint.sh
- (in rusard_site/) ../rusard_site/agent_pack_site_rusard/scripts/test.sh

------
https://chatgpt.com/codex/tasks/task_e_68e4c95209fc832c88ba9872943f2af8