### PR TITLE
Normalize canonical URLs and stabilize pytest configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ Le déploiement :
 * Collecte les fichiers statiques
 * Applique les éventuelles migrations
 
+### 🌍 Variables d'environnement clés (production)
+
+Pour éviter les boucles de redirection et servir le domaine canonique, assure-toi que le fichier `.env.prod` contient :
+
+```env
+DJANGO_ALLOWED_HOSTS=rusard.ch,www.rusard.ch
+CSRF_TRUSTED_ORIGINS=https://rusard.ch https://www.rusard.ch
+DJANGO_SECURE_SSL_REDIRECT=1
+```
+
+Les valeurs peuvent être séparées par des virgules ou des espaces : le helper `parse_env_list` se charge de les normaliser.
+
 ## 📩 Contact
 
 Pour toute question ou suggestion :

--- a/conftest.py
+++ b/conftest.py
@@ -10,3 +10,69 @@ os.environ.setdefault(
     "DJANGO_SETTINGS_MODULE",
     "rusard_site.settings",
 )
+
+import django
+import pytest
+from django.apps import apps
+from django.conf import settings as django_settings
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import Client
+from django.test.utils import setup_test_environment, teardown_test_environment
+
+if not apps.ready:
+    django.setup()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def django_db_setup():
+    """Initialise the Django test environment and database once per test run."""
+
+    setup_test_environment()
+    call_command("migrate", run_syncdb=True, verbosity=0)
+    yield
+    teardown_test_environment()
+
+
+@pytest.fixture
+def client():
+    """Provide a Django test client without requiring pytest-django."""
+
+    return Client()
+
+
+@pytest.fixture
+def django_user_model():
+    """Expose the active user model for tests without pytest-django."""
+
+    return get_user_model()
+
+
+@pytest.fixture
+def settings():
+    """Expose Django settings and restore any modifications after each test."""
+
+    preserved: dict[str, object] = {}
+    for attribute in dir(django_settings):
+        if attribute.isupper():
+            preserved[attribute] = getattr(django_settings, attribute)
+
+    yield django_settings
+
+    current_attributes = {
+        attribute for attribute in dir(django_settings) if attribute.isupper()
+    }
+    for attribute in current_attributes - set(preserved):
+        delattr(django_settings, attribute)
+    for attribute, value in preserved.items():
+        setattr(django_settings, attribute, value)
+
+
+@pytest.fixture(autouse=True)
+def disable_secure_ssl_redirect(settings, monkeypatch):
+    """Avoid HTTPS enforcement during tests so responses keep their status codes."""
+
+    original = getattr(settings, "SECURE_SSL_REDIRECT", False)
+    monkeypatch.setattr(settings, "SECURE_SSL_REDIRECT", False, raising=False)
+    yield
+    monkeypatch.setattr(settings, "SECURE_SSL_REDIRECT", original, raising=False)

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,7 +13,7 @@ services:
     env_file:
       - ./.env.prod
     environment:
-      - VIRTUAL_HOST=rusard.ch
+      - VIRTUAL_HOST=rusard.ch,www.rusard.ch
       - VIRTUAL_PORT=8000
       - LETSENCRYPT_HOST=rusard.ch,www.rusard.ch
       - LETSENCRYPT_EMAIL=contact@rusard.ch

--- a/nginx/vhost.d/www.rusard.ch
+++ b/nginx/vhost.d/www.rusard.ch
@@ -1,7 +1,1 @@
-location /static/ {
-    alias /home/app/web/staticfiles/;
-}
-
-location /media/ {
-    alias /home/app/web/mediafiles/;
-}
+return 301 https://rusard.ch$request_uri;

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = rusard_site.settings
 python_files = tests.py test_*.py *_tests.py
+markers =
+    django_db: allow the test to access the database

--- a/rusard_site/rusard_site/settings.py
+++ b/rusard_site/rusard_site/settings.py
@@ -39,6 +39,13 @@ def parse_env_list(variable_name: str) -> list[str]:
     return [item for item in parts if item]
 
 
+def get_env_flag(variable_name: str, default: bool) -> bool:
+    raw_value = os.environ.get(variable_name)
+    if raw_value is None:
+        return default
+    return raw_value.strip().lower() in {"1", "true", "yes", "on"}
+
+
 ALLOWED_HOSTS = parse_env_list("DJANGO_ALLOWED_HOSTS")
 
 
@@ -185,6 +192,8 @@ STATIC_ROOT = os.path.join(
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+SECURE_SSL_REDIRECT = get_env_flag("DJANGO_SECURE_SSL_REDIRECT", default=not DEBUG)
 
 CSRF_TRUSTED_ORIGINS = parse_env_list("CSRF_TRUSTED_ORIGINS")
 

--- a/rusard_site/rusard_site/urls.py
+++ b/rusard_site/rusard_site/urls.py
@@ -20,8 +20,8 @@ import ts.views as ts_views
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.contrib.sitemaps.views import sitemap
-from django.urls import include, path
-from django.views.generic import TemplateView
+from django.urls import include, path, re_path
+from django.views.generic import RedirectView, TemplateView
 from rusardhome.sitemaps import ArticleSitemap, StaticViewSitemap
 
 sitemaps = {
@@ -32,19 +32,19 @@ sitemaps = {
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("", views.accueil, name="accueil"),
-    path("Accueil/", views.accueil, name="accueil"),
-    path("Modélisation/", views.modelisation, name="modelisation"),
-    path("Blog/", views.blog_list, name="blog_list"),
-    path("Blog/<slug:slug>/", views.blog_detail, name="blog_detail"),
-    path("Blog/<slug:slug>/like/", views.blog_toggle_like, name="blog_toggle_like"),
-    path("About/", views.about, name="about"),
-    path("ProjetAPP/", views.projetapp, name="projetapp"),
-    path("Contact/", views.contact, name="contact"),
+    path("accueil/", views.accueil, name="accueil"),
+    path("modelisation/", views.modelisation, name="modelisation"),
+    path("blog/", views.blog_list, name="blog_list"),
+    path("blog/<slug:slug>/", views.blog_detail, name="blog_detail"),
+    path("blog/<slug:slug>/like/", views.blog_toggle_like, name="blog_toggle_like"),
+    path("about/", views.about, name="about"),
+    path("projetapp/", views.projetapp, name="projetapp"),
+    path("contact/", views.contact, name="contact"),
     path("ts-tpf/", ts_views.tours_services, name="ts"),
-    path("Contact/Confirmation/", views.contactconfirme, name="contactconfirme"),
-    path("Mentions_legales/", views.mentions_legales, name="mentions_legales"),
+    path("contact/confirmation/", views.contactconfirme, name="contactconfirme"),
+    path("mentions-legales/", views.mentions_legales, name="mentions_legales"),
     path(
-        "Politique_de_confidentialite/",
+        "politique-de-confidentialite/",
         views.politique_confidentialite,
         name="politique_confidentialite",
     ),
@@ -64,3 +64,27 @@ urlpatterns = [
     path("accounts/logout/", auth_views.LogoutView.as_view(), name="logout"),
     path("accounts/signup/", views.signup, name="signup"),
 ]
+
+
+legacy_uppercase_patterns = [
+    (r"^Accueil/$", "accueil"),
+    (r"^Mod[ée]lisation/$", "modelisation"),
+    (r"^Blog/$", "blog_list"),
+    (r"^Blog/(?P<slug>[^/]+)/$", "blog_detail"),
+    (r"^Blog/(?P<slug>[^/]+)/like/$", "blog_toggle_like"),
+    (r"^About/$", "about"),
+    (r"^ProjetAPP/$", "projetapp"),
+    (r"^Contact/$", "contact"),
+    (r"^Contact/Confirmation/$", "contactconfirme"),
+    (r"^Mentions_legales/$", "mentions_legales"),
+    (r"^Politique_de_confidentialite/$", "politique_confidentialite"),
+]
+
+
+for pattern, target_name in legacy_uppercase_patterns:
+    urlpatterns.append(
+        re_path(
+            pattern,
+            RedirectView.as_view(pattern_name=target_name, permanent=True),
+        )
+    )


### PR DESCRIPTION
## Summary
- switch site URLs to lowercase slugs and add explicit redirects from the legacy mixed-case routes
- bootstrap pytest so the Django environment and database are ready without pytest-django and skip HTTPS redirects during tests
- register the django_db marker to silence warnings in the suite

## Testing
- ./rusard_site/agent_pack_site_rusard/scripts/format.sh
- ./rusard_site/agent_pack_site_rusard/scripts/lint.sh
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4c95209fc832c88ba9872943f2af8